### PR TITLE
Update README.md - fixed link to training homepage

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This repository contains the modules and learning paths for Microsoft Cloud. The
 
 ### Home, landing, and browse pages
 
-* [Microsoft Learn training home page](/training/)
+* [Microsoft Learn training home page](https://learn.microsoft.com/training/)
 * [Browse all training resources](https://learn.microsoft.com/training/browse/)
 
 To view all of the available landing pages, you can navigate to them from the header of the home page.


### PR DESCRIPTION
Update the link to the Learn homepage. The relative link didn't resolve. I changed it to an absolute URL.

Before requesting or performing a merge in upstream:

- [ ] Verify that your pull request is following our PR quality criteria (items that apply to All and Learn):
       https://review.learn.microsoft.com/help/contribute/contribute-how-to-write-pull-request-quality-criteria?branch=main
- [ ] Verify your PR has a useful title that reflects what it is for.
